### PR TITLE
MICA-381 update to node-logstash for nodejs 12.14.1 environment

### DIFF
--- a/lib/inputs/input_zeromq.js
+++ b/lib/inputs/input_zeromq.js
@@ -1,6 +1,6 @@
 var base_input = require('../lib/base_input'),
   util = require('util'),
-  zmq = require('zmq'),
+  zmq = require('zeromq'),
   logger = require('log4node');
 
 function InputZeroMQ() {

--- a/lib/outputs/abstract_zeromq.js
+++ b/lib/outputs/abstract_zeromq.js
@@ -1,6 +1,6 @@
 var base_output = require('../lib/base_output'),
   util = require('util'),
-  zmq = require('zmq'),
+  zmq = require('zeromq'),
   logger = require('log4node');
 
 function AbstractZeroMQ() {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "maxmind-geolite-mirror": "1.0.x",
     "http-proxy-agent": "1.x",
     "https-proxy-agent": "1.x",
-    "lumberjack-protocol": "git://github.com/benbria/node-lumberjack-protocol.git",
+    "lumberjack-protocol": "git://github.com/bpaquet/node-lumberjack-protocol.git",
     "hep-js": "0.0.4"
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -25,22 +25,24 @@
     "test": "./test-runner.sh"
   },
   "dependencies": {
+    "crypto-browserify": "^3.12.0",
     "log4node": "0.1.6",
     "optimist": "0.6.1",
     "mkdirp": "0.5.1",
-    "async": "0.9.0",
-    "lru-cache": "2.7.x"
+    "async": "^3.1.0",
+    "lru-cache": "2.7.x",
+    "uuid": "^3.3.3"
   },
   "optionalDependencies":{
-    "aws-sdk": "2.7.x",
-    "amqplib": "0.4.0",
-    "zmq": "2.15.3",
+    "aws-sdk": "2.505.0",
+    "amqplib": "^0.5.5",
+    "zeromq": "^5.2.0",
     "moment": "2.9.0",
-    "redis": "2.2.5",
-    "ws": "0.8.0",
-    "oniguruma": "5.1.x",
+    "redis": "2.8.0",
+    "ws": "7.2.1",
+    "oniguruma": "7.2.1",
     "msgpack": "1.0.x",
-    "geoip-lite": "1.1.6",
+    "geoip-lite": "1.4.0",
     "maxmind": "0.6.x",
     "maxmind-geolite-mirror": "1.0.x",
     "http-proxy-agent": "1.x",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "maxmind-geolite-mirror": "1.0.x",
     "http-proxy-agent": "1.x",
     "https-proxy-agent": "1.x",
-    "lumberjack-protocol": "git://github.com/bpaquet/node-lumberjack-protocol.git",
+    "lumberjack-protocol": "git://github.com/benbria/node-lumberjack-protocol.git",
     "hep-js": "0.0.4"
   },
   "directories": {

--- a/test/zmq_injector.js
+++ b/test/zmq_injector.js
@@ -1,6 +1,6 @@
 var events = require('events'),
   log = require('log4node'),
-  zmq = require('zmq');
+  zmq = require('zeromq');
 
 var target = process.argv[2];
 var type = process.argv[3];


### PR DESCRIPTION
The following changes are needed to get node-logstash installing on node.  Mainly just updating dependencies and the migration of the now depricated zmq to zeromq.  

I've deployed this branch with https://github.com/morpheus-med/middle/pull/9844 and verified that the test cluster nod12 was writing logs back to AWS log console. 